### PR TITLE
Explorer fix & features, see desc

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -51,7 +51,7 @@
         },
         "verde.coloredSelection": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Use a custom color for selected items in the explorer tree"
         },
         "verde.coloredSelectionColor": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -48,6 +48,16 @@
           "type": "boolean",
           "default": true,
           "description": "When enabled, Ctrl+P opens the Go to Instance menu instead of VS Code's Quick Open (only when the Verde explorer is focused)"
+        },
+        "verde.coloredSelection": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use a custom color for selected items in the explorer tree"
+        },
+        "verde.coloredSelectionColor": {
+          "type": "string",
+          "default": "#264f78",
+          "description": "Background color for selected items when Colored Selection is true"
         }
       }
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -51,13 +51,13 @@
         },
         "verde.coloredSelection": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Use a custom color for selected items in the explorer tree"
         },
         "verde.coloredSelectionColor": {
           "type": "string",
           "default": "#264f78",
-          "description": "Background color for selected items when Colored Selection is true"
+          "description": "Background color for selected items when Colored Selection is enabled"
         }
       }
     },
@@ -89,6 +89,12 @@
         "command": "verde.refreshExplorer",
         "title": "Refresh",
         "icon": "$(refresh)",
+        "category": "Verde"
+      },
+      {
+        "command": "verde.collapseAll",
+        "title": "Collapse All",
+        "icon": "$(collapse-all)",
         "category": "Verde"
       },
       {
@@ -249,6 +255,11 @@
       "view/title": [
         {
           "command": "verde.refreshExplorer",
+          "when": "view == verde.view",
+          "group": "navigation"
+        },
+        {
+          "command": "verde.collapseAll",
           "when": "view == verde.view",
           "group": "navigation"
         }

--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -83,11 +83,17 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     };
     webviewView.webview.onDidReceiveMessage(m => this.onMessage(m));
     webviewView.onDidDispose(() => { this.webviewView = undefined; });
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration("verde.coloredSelection") || e.affectsConfiguration("verde.coloredSelectionColor")) {
+        this.pushSelectionColor();
+      }
+    });
     const assetBase = webviewView.webview.asWebviewUri(
       vscode.Uri.joinPath(this.extensionUri, "assets")
     ).toString();
     webviewView.webview.html = this.buildHtml(webviewView.webview, assetBase);
     this.pushTree();
+    this.pushSelectionColor();
   }
 
   public refreshWebviewHtml(): void {
@@ -101,6 +107,15 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
 
   private post(msg: unknown): void {
     this.webviewView?.webview.postMessage(msg);
+  }
+
+  private pushSelectionColor(): void {
+    const cfg = vscode.workspace.getConfiguration("verde");
+    this.post({
+      type: "updateSelectionColor",
+      enabled: cfg.get<boolean>("coloredSelection", false),
+      color: cfg.get<string>("coloredSelectionColor", "#264f78"),
+    });
   }
 
   private pushTree(): void {
@@ -289,6 +304,7 @@ body{display:flex;flex-direction:column}
 .qa-item:not(.selected):hover{background:var(--vscode-list-hoverBackground)}
 .qa-icon{width:16px;height:16px;margin-right:8px;image-rendering:pixelated;flex-shrink:0}
 </style>
+<style id="sel-override"></style>
 ${themeScript}
 </head>
 <body>
@@ -314,8 +330,10 @@ var searchFilter='';
 var qaParentId=null,qaFiltered=CLASSES,qaIdx=0,qaOutsideClick=null;
 var ctxNodeId=null;
 var renameNodeId=null;
-var SLOW_CLICK_RENAME_DELAY=600;
-var slowClickTimer=null,slowClickId=null;
+var SLOW_CLICK_RENAME_DELAY=800;
+var DBLCLICK_THRESHOLD=400;
+var slowClickTimer=null;
+var lastClickTime=0,lastClickId=null;
 
 var expandedIds=new Set();
 var dragSourceId=null;
@@ -370,6 +388,14 @@ window.addEventListener('message',function(e){
           qaFiltered=qq?CLASSES.filter(function(c){return c.toLowerCase().indexOf(qq)>=0}):CLASSES;
           qaIdx=0;renderQA();
         }
+      }
+      break;
+    case 'updateSelectionColor':
+      var so=document.getElementById('sel-override');
+      if(so){
+        if(m.enabled&&m.color){
+          so.textContent='.tree-row.selected{background:'+m.color+' !important}#tree:focus-within .tree-row.selected{background:'+m.color+' !important}';
+        }else{so.textContent=''}
       }
       break;
   }
@@ -550,45 +576,46 @@ treeEl.addEventListener('click',function(e){
   treeEl.focus();
   if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
   var row=e.target.closest('.tree-row');
-  if(!row){slowClickId=null;selectedIds=[];updateSelVis();vscode.postMessage({type:'selectionChanged',nodeIds:[]});return}
+  if(!row){lastClickId=null;selectedIds=[];updateSelVis();vscode.postMessage({type:'selectionChanged',nodeIds:[]});return}
   var id=row.dataset.id;
   var arrow=e.target.closest('.tree-arrow');
   if(arrow&&!arrow.classList.contains('leaf')){
-    slowClickId=null;
+    lastClickId=null;
     if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
     saveExp();renderTree();return;
   }
-  if(e.target.closest('.tree-add-btn')){slowClickId=null;openQA(id,row);return}
-  if(e.ctrlKey||e.metaKey){slowClickId=null;var i=selectedIds.indexOf(id);if(i>=0)selectedIds.splice(i,1);else selectedIds.push(id)}
+  if(e.target.closest('.tree-add-btn')){lastClickId=null;openQA(id,row);return}
+  var now=Date.now();
+  var isDbl=id===lastClickId&&now-lastClickTime<DBLCLICK_THRESHOLD&&!e.ctrlKey&&!e.metaKey;
+  lastClickTime=now;
+  lastClickId=id;
+  if(isDbl){
+    lastClickId=null;
+    if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
+    var node=nodes[id];
+    if(node&&node.children.length>0){
+      if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
+      saveExp();renderTree();
+    }
+    return;
+  }
+  if(e.ctrlKey||e.metaKey){var i=selectedIds.indexOf(id);if(i>=0)selectedIds.splice(i,1);else selectedIds.push(id)}
   else{
     var wasOnlySel=selectedIds.length===1&&selectedIds[0]===id;
     selectedIds=[id];
-    if(wasOnlySel&&slowClickId===id&&!renameNodeId){
-      slowClickTimer=setTimeout(function(){slowClickTimer=null;slowClickId=null;renameNodeId=id;renderTree();afterRenameInputMount()},SLOW_CLICK_RENAME_DELAY);
+    if(wasOnlySel&&!renameNodeId){
+      slowClickTimer=setTimeout(function(){slowClickTimer=null;renameNodeId=id;renderTree();afterRenameInputMount()},SLOW_CLICK_RENAME_DELAY);
     }
-    slowClickId=id;
   }
   updateSelVis();
   vscode.postMessage({type:'selectionChanged',nodeIds:selectedIds.slice()});
 });
 
-treeEl.addEventListener('dblclick',function(e){
-  if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
-  slowClickId=null;
-  var row=e.target.closest('.tree-row');
-  if(!row||e.target.closest('.tree-arrow')||e.target.closest('.tree-add-btn'))return;
-  var id=row.dataset.id;
-  if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
-  var node=nodes[id];
-  if(node&&node.children.length>0){
-    if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
-    saveExp();renderTree();
-  }
-});
+treeEl.addEventListener('dblclick',function(e){e.preventDefault()});
 
 treeEl.addEventListener('contextmenu',function(e){
   if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
-  slowClickId=null;
+  lastClickId=null;
   e.preventDefault();
   var row=e.target.closest('.tree-row');if(!row)return;
   var id=row.dataset.id;
@@ -600,7 +627,7 @@ treeEl.addEventListener('contextmenu',function(e){
 function clearDragOver(){treeEl.querySelectorAll('.tree-row').forEach(function(r){r.classList.remove('drag-over')})}
 treeEl.addEventListener('dragstart',function(e){
   if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
-  slowClickId=null;
+  lastClickId=null;
   if(e.target.closest('.tree-arrow,.tree-add-btn,.tree-rename-input')){e.preventDefault();return}
   var row=e.target.closest('.tree-row');if(!row)return;
   dragSourceId=row.dataset.id;

--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -314,6 +314,8 @@ var searchFilter='';
 var qaParentId=null,qaFiltered=CLASSES,qaIdx=0,qaOutsideClick=null;
 var ctxNodeId=null;
 var renameNodeId=null;
+var SLOW_CLICK_RENAME_DELAY=600;
+var slowClickTimer=null,slowClickId=null;
 
 var expandedIds=new Set();
 var dragSourceId=null;
@@ -375,11 +377,22 @@ window.addEventListener('message',function(e){
 
 /* ---- search ---- */
 var searchDebounce=null;
+function expandSearchMatches(){
+  visCache={};
+  function walk(id){
+    var n=nodes[id];if(!n)return;
+    if(!isVis(id))return;
+    if(n.children.length>0)expandedIds.add(id);
+    for(var i=0;i<n.children.length;i++)walk(n.children[i]);
+  }
+  for(var i=0;i<rootIds.length;i++)walk(rootIds[i]);
+  saveExp();
+}
 searchEl.addEventListener('input',function(){
   var raw=searchEl.value.trim().toLowerCase();
   if(searchDebounce)clearTimeout(searchDebounce);
   if(!raw){searchFilter='';renderTree();return}
-  searchDebounce=setTimeout(function(){searchFilter=raw;renderTree()},50);
+  searchDebounce=setTimeout(function(){searchFilter=raw;expandSearchMatches();renderTree()},50);
 });
 searchEl.addEventListener('keydown',function(e){
   if(e.key==='Escape'){searchEl.value='';searchFilter='';renderTree();treeEl.focus();e.preventDefault()}
@@ -438,7 +451,7 @@ function buildFlatRows(){
     if(searchFilter&&!isVis(id))return;
     var n=nodes[id];if(!n)return;
     var has=n.children.length>0;
-    var exp=searchFilter?has:expandedIds.has(id);
+    var exp=expandedIds.has(id);
     flatRows.push({id:id,depth:depth});
     if(exp)for(var i=0;i<n.children.length;i++)walk(n.children[i],depth+1);
   }
@@ -477,7 +490,7 @@ function renderViewport(){
 function buildRowHtml(id,depth,h){
   var n=nodes[id];if(!n)return;
   var has=n.children.length>0;
-  var exp=searchFilter?has:expandedIds.has(id);
+  var exp=expandedIds.has(id);
   var sel=selectedIds.indexOf(id)>=0;
   var pad=depth*INDENT;
   var ac=has?(exp?' expanded':''):' leaf';
@@ -535,28 +548,47 @@ function scrollTo(id){
 /* ---- tree events ---- */
 treeEl.addEventListener('click',function(e){
   treeEl.focus();
+  if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
   var row=e.target.closest('.tree-row');
-  if(!row){selectedIds=[];updateSelVis();vscode.postMessage({type:'selectionChanged',nodeIds:[]});return}
+  if(!row){slowClickId=null;selectedIds=[];updateSelVis();vscode.postMessage({type:'selectionChanged',nodeIds:[]});return}
   var id=row.dataset.id;
   var arrow=e.target.closest('.tree-arrow');
   if(arrow&&!arrow.classList.contains('leaf')){
+    slowClickId=null;
     if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
     saveExp();renderTree();return;
   }
-  if(e.target.closest('.tree-add-btn')){openQA(id,row);return}
-  if(e.ctrlKey||e.metaKey){var i=selectedIds.indexOf(id);if(i>=0)selectedIds.splice(i,1);else selectedIds.push(id)}
-  else selectedIds=[id];
+  if(e.target.closest('.tree-add-btn')){slowClickId=null;openQA(id,row);return}
+  if(e.ctrlKey||e.metaKey){slowClickId=null;var i=selectedIds.indexOf(id);if(i>=0)selectedIds.splice(i,1);else selectedIds.push(id)}
+  else{
+    var wasOnlySel=selectedIds.length===1&&selectedIds[0]===id;
+    selectedIds=[id];
+    if(wasOnlySel&&slowClickId===id&&!renameNodeId){
+      slowClickTimer=setTimeout(function(){slowClickTimer=null;slowClickId=null;renameNodeId=id;renderTree();afterRenameInputMount()},SLOW_CLICK_RENAME_DELAY);
+    }
+    slowClickId=id;
+  }
   updateSelVis();
   vscode.postMessage({type:'selectionChanged',nodeIds:selectedIds.slice()});
 });
 
 treeEl.addEventListener('dblclick',function(e){
+  if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
+  slowClickId=null;
   var row=e.target.closest('.tree-row');
   if(!row||e.target.closest('.tree-arrow')||e.target.closest('.tree-add-btn'))return;
-  if(row.dataset.s==='1')vscode.postMessage({type:'scriptActivated',nodeId:row.dataset.id});
+  var id=row.dataset.id;
+  if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
+  var node=nodes[id];
+  if(node&&node.children.length>0){
+    if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
+    saveExp();renderTree();
+  }
 });
 
 treeEl.addEventListener('contextmenu',function(e){
+  if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
+  slowClickId=null;
   e.preventDefault();
   var row=e.target.closest('.tree-row');if(!row)return;
   var id=row.dataset.id;
@@ -567,6 +599,8 @@ treeEl.addEventListener('contextmenu',function(e){
 /* ---- drag and drop ---- */
 function clearDragOver(){treeEl.querySelectorAll('.tree-row').forEach(function(r){r.classList.remove('drag-over')})}
 treeEl.addEventListener('dragstart',function(e){
+  if(slowClickTimer){clearTimeout(slowClickTimer);slowClickTimer=null}
+  slowClickId=null;
   if(e.target.closest('.tree-arrow,.tree-add-btn,.tree-rename-input')){e.preventDefault();return}
   var row=e.target.closest('.tree-row');if(!row)return;
   dragSourceId=row.dataset.id;

--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -51,6 +51,10 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     this.post({ type: "updateClasses", classes: getClassNames() });
   }
 
+  public collapseAll(): void {
+    this.post({ type: "collapseAll" });
+  }
+
   public reveal(node: Node): void {
     const ancestors: string[] = [];
     let cur: Node | undefined = node;
@@ -336,11 +340,13 @@ var slowClickTimer=null;
 var lastClickTime=0,lastClickId=null;
 
 var expandedIds=new Set();
+var searchExpandedIds=new Set();
+var savedExpandedIds=null;
 var dragSourceId=null;
 var saved=vscode.getState();
 if(saved&&Array.isArray(saved.exp))expandedIds=new Set(saved.exp);
-function saveExp(){vscode.setState({exp:[...expandedIds]})}
-
+function activeExp(){return searchFilter?searchExpandedIds:expandedIds}
+function saveExp(){if(!searchFilter)vscode.setState({exp:[...expandedIds]})}
 function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}
 
 var treeEl=document.getElementById('tree');
@@ -398,6 +404,14 @@ window.addEventListener('message',function(e){
         }else{so.textContent=''}
       }
       break;
+    case 'collapseAll':
+      expandedIds.clear();
+      searchExpandedIds.clear();
+      savedExpandedIds=null;
+      for(var i=0;i<selectedIds.length;i++)expandAncestors(selectedIds[i]);
+      saveExp();renderTree();
+      if(selectedIds.length>0)requestAnimationFrame(function(){scrollTo(selectedIds[0])});
+      break;
   }
 });
 
@@ -405,23 +419,41 @@ window.addEventListener('message',function(e){
 var searchDebounce=null;
 function expandSearchMatches(){
   visCache={};
+  searchExpandedIds=new Set(expandedIds);
   function walk(id){
     var n=nodes[id];if(!n)return;
     if(!isVis(id))return;
-    if(n.children.length>0)expandedIds.add(id);
+    if(n.children.length>0)searchExpandedIds.add(id);
     for(var i=0;i<n.children.length;i++)walk(n.children[i]);
   }
   for(var i=0;i<rootIds.length;i++)walk(rootIds[i]);
-  saveExp();
+}
+function expandAncestors(id){
+  var n=nodes[id];if(!n)return;
+  for(var k in nodes){
+    var p=nodes[k];
+    if(p.children.indexOf(id)>=0){expandedIds.add(k);expandAncestors(k);return}
+  }
 }
 searchEl.addEventListener('input',function(){
   var raw=searchEl.value.trim().toLowerCase();
   if(searchDebounce)clearTimeout(searchDebounce);
-  if(!raw){searchFilter='';renderTree();return}
+  if(!raw){
+    if(savedExpandedIds){expandedIds=savedExpandedIds;savedExpandedIds=null}
+    for(var i=0;i<selectedIds.length;i++)expandAncestors(selectedIds[i]);
+    saveExp();
+    searchFilter='';renderTree();return;
+  }
+  if(!savedExpandedIds)savedExpandedIds=new Set(expandedIds);
   searchDebounce=setTimeout(function(){searchFilter=raw;expandSearchMatches();renderTree()},50);
 });
 searchEl.addEventListener('keydown',function(e){
-  if(e.key==='Escape'){searchEl.value='';searchFilter='';renderTree();treeEl.focus();e.preventDefault()}
+  if(e.key==='Escape'){
+    if(savedExpandedIds){expandedIds=savedExpandedIds;savedExpandedIds=null}
+    for(var i=0;i<selectedIds.length;i++)expandAncestors(selectedIds[i]);
+    saveExp();
+    searchEl.value='';searchFilter='';renderTree();treeEl.focus();e.preventDefault();
+  }
 });
 
 var visCache={};
@@ -477,7 +509,7 @@ function buildFlatRows(){
     if(searchFilter&&!isVis(id))return;
     var n=nodes[id];if(!n)return;
     var has=n.children.length>0;
-    var exp=expandedIds.has(id);
+    var exp=activeExp().has(id);
     flatRows.push({id:id,depth:depth});
     if(exp)for(var i=0;i<n.children.length;i++)walk(n.children[i],depth+1);
   }
@@ -516,7 +548,7 @@ function renderViewport(){
 function buildRowHtml(id,depth,h){
   var n=nodes[id];if(!n)return;
   var has=n.children.length>0;
-  var exp=expandedIds.has(id);
+  var exp=activeExp().has(id);
   var sel=selectedIds.indexOf(id)>=0;
   var pad=depth*INDENT;
   var ac=has?(exp?' expanded':''):' leaf';
@@ -581,7 +613,7 @@ treeEl.addEventListener('click',function(e){
   var arrow=e.target.closest('.tree-arrow');
   if(arrow&&!arrow.classList.contains('leaf')){
     lastClickId=null;
-    if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
+    var ae=activeExp();if(ae.has(id))ae.delete(id);else ae.add(id);
     saveExp();renderTree();return;
   }
   if(e.target.closest('.tree-add-btn')){lastClickId=null;openQA(id,row);return}
@@ -594,7 +626,7 @@ treeEl.addEventListener('click',function(e){
     if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
     var node=nodes[id];
     if(node&&node.children.length>0){
-      if(expandedIds.has(id))expandedIds.delete(id);else expandedIds.add(id);
+      var ae=activeExp();if(ae.has(id))ae.delete(id);else ae.add(id);
       saveExp();renderTree();
     }
     return;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -258,6 +258,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 
 	context.subscriptions.push(
+		vscode.commands.registerCommand("verde.collapseAll", () => {
+			explorerViewProvider.collapseAll();
+		})
+	);
+
+	context.subscriptions.push(
 		vscode.commands.registerCommand("verde.showOutput", () => {
 			outputChannel.show(true);
 		})


### PR DESCRIPTION
Commit batch 1:

- Fixed UX issue where instances couldn't be collapsed/expanded during a search

- Added double click to collapse/expand, and single click on a selected instance to rename(same behavior as Studio)

- Added selection color(configurable in extension settings, defaults to a nice bright blue)

Video of changes:

https://github.com/user-attachments/assets/7af718c7-0270-4097-8a98-f4d8f5172233

Commit batch 2:

- Better expansion behavior while searching. Collapsing/Expanding instances during a search won't persist when you've cleared the search, meaning if you search for something and clear it, your whole hierarchy will no longer be expanded - only whatever you had expanded before the search + your current selection and its ancestors 

- Added a "Collapse All" button to the top bar of the explorer, which will collapse all instances besides your current selection

Video of changes:

https://github.com/user-attachments/assets/a4417038-b3fc-43d6-9b55-a01b2d3abd8a

You can attach these videos and explanations in the discord if you'd like

