### PR TITLE
Fix explorer search cold start

### DIFF
--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -11,6 +11,7 @@ type WebviewNode = {
   id: string;
   name: string;
   className: string;
+  parentId: string | null;
   iconClassName: string;
   hasChildren: boolean;
   isScript: boolean;
@@ -19,6 +20,11 @@ type WebviewNode = {
 };
 
 type FullSyncStatus = "unknown" | "full" | "too_big";
+
+type SearchResultsPayload = {
+  nodes: WebviewNode[];
+  matchIds: string[];
+};
 
 const MAX_LOCAL_SEARCH_RESULTS = 500;
 
@@ -64,7 +70,7 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
   }
 
   public reissueServerSearch(): boolean {
-    if (this.fullSyncStatus === "too_big" && this.currentSearchQuery.length >= 2) {
+    if (this.currentSearchQuery.length >= 2) {
       this.backend.requestSearch(this.currentSearchQuery);
       return true;
     }
@@ -105,74 +111,102 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
   }
 
   private handleSearchInput(query: string): void {
-    this.currentSearchQuery = query;
+    this.currentSearchQuery = query.trim().toLowerCase();
+    this.pendingSearchQuery = null;
 
-    if (query === "") {
-      this.pendingSearchQuery = null;
+    if (this.currentSearchQuery === "") {
       this.backend.requestSearch("");
-      this.postSearchResults("", []);
+      this.postSearchResults("", { nodes: [], matchIds: [] });
       return;
     }
 
-    if (this.fullSyncStatus === "full") {
-      this.pendingSearchQuery = null;
-      this.postSearchResults(query, this.computeLocalMatches(query));
+    if (this.currentSearchQuery.length < 2) {
+      this.backend.requestSearch("");
+      this.postSearchResults(this.currentSearchQuery, { nodes: [], matchIds: [] });
       return;
     }
 
-    if (this.fullSyncStatus === "too_big") {
-      this.pendingSearchQuery = null;
-      if (query.length < 2) {
-        this.backend.requestSearch("");
-        this.postSearchResults(query, []);
-        return;
+    if (!this.backend.requestSearch(this.currentSearchQuery)) {
+      if (this.fullSyncStatus === "full") {
+        this.postSearchResults(this.currentSearchQuery, this.computeLocalMatches(this.currentSearchQuery));
+      } else {
+        this.postSearchResults(this.currentSearchQuery, { nodes: [], matchIds: [] });
       }
-      if (!this.backend.requestSearch(query)) {
-        this.postSearchResults(query, []);
-      }
-      return;
     }
-
-    this.pendingSearchQuery = query;
-    this.requestFullSnapshotForQuery(query);
   }
 
   public handleSearchResults(query: string, nodes: Node[]): void {
-    if (this.fullSyncStatus !== "too_big") return;
-    if (query.toLowerCase() !== this.currentSearchQuery) return;
-
-    const tokens = this.searchTokens(this.currentSearchQuery);
-    const pathCache = new Map<string, string>();
-    const rows: WebviewNode[] = [];
-    for (const raw of nodes) {
-      const node = this.explorerProvider.getNodeById(raw.id) ?? raw;
-      if (this.matchesTokens(node, tokens, pathCache)) {
-        rows.push(this.serializeNode(node));
-      }
+    const normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery !== this.currentSearchQuery) {
+      return;
     }
-    this.postSearchResults(this.currentSearchQuery, rows);
+
+    this.postSearchResults(this.currentSearchQuery, this.buildSearchResults(this.currentSearchQuery, nodes));
   }
 
-  private postSearchResults(query: string, nodes: WebviewNode[]): void {
-    this.post({ type: "searchResults", query, nodes });
+  private postSearchResults(query: string, results: SearchResultsPayload): void {
+    this.post({ type: "searchResults", query, nodes: results.nodes, matchIds: results.matchIds });
   }
 
   private searchTokens(query: string): string[] {
     return query.toLowerCase().split(/[\s.]+/).filter(t => t.length > 0);
   }
 
-  private computeLocalMatches(query: string): WebviewNode[] {
+  private buildSearchResults(query: string, sourceNodes: Node[]): SearchResultsPayload {
     const tokens = this.searchTokens(query);
-    if (tokens.length === 0) return [];
     const pathCache = new Map<string, string>();
     const rows: WebviewNode[] = [];
-    for (const node of this.explorerProvider.getAllNodes()) {
-      if (this.matchesTokens(node, tokens, pathCache)) {
+    const matchIds: string[] = [];
+    const seen = new Set<string>();
+
+    for (const raw of sourceNodes) {
+      const node = this.explorerProvider.getNodeById(raw.id) ?? raw;
+      if (!seen.has(node.id)) {
         rows.push(this.serializeNode(node));
-        if (rows.length >= MAX_LOCAL_SEARCH_RESULTS) break;
+        seen.add(node.id);
+      }
+      if (this.matchesTokens(node, tokens, pathCache)) {
+        matchIds.push(node.id);
       }
     }
-    return rows;
+
+    return { nodes: rows, matchIds };
+  }
+
+  private computeLocalMatches(query: string): SearchResultsPayload {
+    const tokens = this.searchTokens(query);
+    if (tokens.length === 0) {
+      return { nodes: [], matchIds: [] };
+    }
+    const pathCache = new Map<string, string>();
+    const rows: WebviewNode[] = [];
+    const matchIds: string[] = [];
+    const seen = new Set<string>();
+    const addWithAncestors = (node: Node): void => {
+      if (seen.has(node.id)) {
+        return;
+      }
+      if (node.parentId !== null) {
+        const parent = this.explorerProvider.getNodeById(node.parentId);
+        if (parent) {
+          addWithAncestors(parent);
+        }
+      }
+      if (!seen.has(node.id)) {
+        rows.push(this.serializeNode(node));
+        seen.add(node.id);
+      }
+    };
+    for (const node of this.explorerProvider.getAllNodes()) {
+      if (this.matchesTokens(node, tokens, pathCache)) {
+        matchIds.push(node.id);
+        addWithAncestors(node);
+        if (matchIds.length >= MAX_LOCAL_SEARCH_RESULTS) {
+          break;
+        }
+      }
+    }
+    return { nodes: rows, matchIds };
   }
 
   private matchesTokens(node: Node, tokens: string[], pathCache: Map<string, string>): boolean {
@@ -239,17 +273,31 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     return { chain, preload };
   }
 
-  public reveal(node: Node): void {
+  public reveal(node: Node, options?: { preserveFocus?: boolean; select?: boolean }): void {
     const { chain, preload } = this.buildAncestorPreload(node);
-    this.selectedIds = [node.id];
-    this.post({
+    const shouldSelect = options?.select !== false;
+    const message: {
+      type: "revealNode";
+      nodeId: string;
+      chain: string[];
+      preload: Record<string, WebviewNode[]>;
+      preserveFocus: boolean;
+      selectedIds?: string[];
+    } = {
       type: "revealNode",
       nodeId: node.id,
       chain,
       preload,
-      selectedIds: [node.id],
-    });
-    this.fireSelectionChanged();
+      preserveFocus: options?.preserveFocus === true,
+    };
+    if (shouldSelect) {
+      this.selectedIds = [node.id];
+      message.selectedIds = [node.id];
+    }
+    this.post(message);
+    if (shouldSelect) {
+      this.fireSelectionChanged();
+    }
   }
 
   public resolveWebviewView(
@@ -380,6 +428,7 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
       id: n.id,
       name: n.name,
       className: n.className,
+      parentId: n.parentId,
       iconClassName: scriptIconClass(n.className, n.runContext),
       hasChildren: n.hasChildren === true || n.children.length > 0,
       isScript,
@@ -479,6 +528,17 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
         this.handleSearchInput(query);
         break;
       }
+      case "revealSearchResult": {
+        const nodeId = typeof msg.nodeId === "string" ? msg.nodeId : "";
+        const node = this.explorerProvider.getNodeById(nodeId);
+        if (node) {
+          this.reveal(node, {
+            preserveFocus: msg.preserveFocus === true,
+            select: msg.select !== false,
+          });
+        }
+        break;
+      }
       case "releaseSubtree": {
         const parentIds = Array.isArray(msg.parentIds)
           ? msg.parentIds.filter((id: unknown): id is string => typeof id === "string")
@@ -575,6 +635,7 @@ body{display:flex;flex-direction:column}
 .tree-row{display:flex;align-items:center;height:22px;cursor:pointer;padding-right:0;white-space:nowrap;user-select:none;position:absolute;left:0;right:0}
 .tree-row:hover{background:var(--vscode-list-hoverBackground)}
 .tree-row.selected{background:var(--vscode-list-inactiveSelectionBackground);color:var(--vscode-list-inactiveSelectionForeground)}
+.tree-row.previewed{background:var(--vscode-list-hoverBackground);outline:1px solid var(--vscode-focusBorder);outline-offset:-1px}
 #tree:focus-within .tree-row.selected{background:var(--vscode-list-activeSelectionBackground);color:var(--vscode-list-activeSelectionForeground)}
 .tree-row.dragging{opacity:0.5}
 .tree-row.drag-over{background:var(--vscode-list-dropBackground);outline:1px solid var(--vscode-focusBorder)}
@@ -675,6 +736,7 @@ function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g
 var lastSearchQuerySent=null;
 var localSyncStatus='unknown';
 var searchResultIds=null;
+var searchTreeIds=null;
 function sendSearchQuery(q){
   if(q===lastSearchQuerySent)return;
   lastSearchQuerySent=q;
@@ -726,14 +788,22 @@ window.addEventListener('message',function(e){
       rootIds=[];for(var i=0;i<(m.rootNodes||[]).length;i++)rootIds.push(m.rootNodes[i].id);
       childrenByParent['']=rootIds.slice();
       selectedIds=m.selectedIds||[];
-      lastSearchQuerySent=null;searchResultIds=null;
+      lastSearchQuerySent=null;searchResultIds=null;searchTreeIds=null;previewRevealNodeId=null;pendingPreviewSearchQuery=null;pendingPreviewNodeId=null;
       if(searchFilter)sendSearchQuery(searchFilter);
       renderTree();break;
     case 'searchResults':
       if(m.query!==searchFilter)break;
-      ingestNodes(m.nodes||[]);
-      searchResultIds=[];for(var i=0;i<(m.nodes||[]).length;i++)searchResultIds.push(m.nodes[i].id);
-      renderTree();break;
+      var resultNodes=m.nodes||[];
+      ingestNodes(resultNodes);
+      searchTreeIds=[];
+      for(var i=0;i<resultNodes.length;i++)searchTreeIds.push(resultNodes[i].id);
+      searchResultIds=[];
+      var matchIds=Array.isArray(m.matchIds)?m.matchIds:null;
+      if(matchIds){for(var i=0;i<matchIds.length;i++){if(nodes[matchIds[i]])searchResultIds.push(matchIds[i])}}
+      else{for(var i=0;i<resultNodes.length;i++)searchResultIds.push(resultNodes[i].id)}
+      previewRevealNodeId=null;pendingPreviewSearchQuery=null;pendingPreviewNodeId=null;
+      renderTree();
+      break;
     case 'children':
       delete pendingChildren[m.parentId];
       storeChildren(m.parentId,m.nodes||[]);
@@ -771,9 +841,10 @@ window.addEventListener('message',function(e){
       var pre=m.preload||{};
       for(var pid in pre){storeChildren(pid,pre[pid])}
       for(var i=0;i<chain.length;i++)expandedIds.add(chain[i]);
-      selectedIds=m.selectedIds||[];
+      if(Array.isArray(m.selectedIds))selectedIds=m.selectedIds;
+      if(m.preserveFocus){previewRevealNodeId=m.nodeId||null;pendingPreviewSearchQuery=null;pendingPreviewNodeId=null}
       saveExp();renderTree();
-      requestAnimationFrame(function(){scrollTo(m.nodeId);treeEl.focus()});break;
+      requestAnimationFrame(function(){scrollTo(m.nodeId);if(!m.preserveFocus)treeEl.focus()});break;
     case 'focusTree':
       treeEl.focus();break;
     case 'scrollToNode':
@@ -829,26 +900,51 @@ window.addEventListener('message',function(e){
 
 var searchDebounce=null;
 var searchFilter='';
+var previewRevealNodeId=null;
+var pendingPreviewSearchQuery=null;
+var pendingPreviewNodeId=null;
+function revealSearchResult(id){
+  if(!id)return;
+  clearTimeout(searchDebounce);searchDebounce=null;
+  searchEl.value='';
+  searchFilter='';
+  searchResultIds=null;
+  searchTreeIds=null;
+  previewRevealNodeId=null;
+  pendingPreviewSearchQuery=null;pendingPreviewNodeId=null;
+  lastSearchQuerySent=null;
+  renderTree();
+  vscode.postMessage({type:'revealSearchResult',nodeId:id});
+  setTimeout(function(){sendSearchQuery('')},0);
+}
+function previewSearchResult(id,query){
+  if(!id)return;
+  pendingPreviewSearchQuery=query||searchFilter;
+  pendingPreviewNodeId=id;
+  vscode.postMessage({type:'revealSearchResult',nodeId:id,preserveFocus:true,select:false});
+}
 searchEl.addEventListener('input',function(){
   var raw=searchEl.value.trim().toLowerCase();
-  if(searchDebounce)clearTimeout(searchDebounce);
+  clearTimeout(searchDebounce);
   if(!raw){
-    lastSearchQuerySent=null;searchResultIds=null;
+    lastSearchQuerySent=null;searchResultIds=null;searchTreeIds=null;previewRevealNodeId=null;pendingPreviewSearchQuery=null;pendingPreviewNodeId=null;
     sendSearchQuery('');
     searchFilter='';renderTree();return;
   }
-  searchDebounce=setTimeout(function(){
-    if(raw!==searchFilter)searchResultIds=null;
-    sendSearchQuery(raw);
-    searchFilter=raw;renderTree();
-  },50);
+  if(raw!==searchFilter){searchResultIds=null;searchTreeIds=null;previewRevealNodeId=null;pendingPreviewSearchQuery=null;pendingPreviewNodeId=null}
+  searchFilter=raw;
+  renderTree();
+  sendSearchQuery(raw);
 });
 searchEl.addEventListener('keydown',function(e){
   if(e.key==='Escape'){
-    if(searchDebounce){clearTimeout(searchDebounce);searchDebounce=null}
-    lastSearchQuerySent=null;searchResultIds=null;
+    clearTimeout(searchDebounce);searchDebounce=null;
+    lastSearchQuerySent=null;searchResultIds=null;searchTreeIds=null;previewRevealNodeId=null;
     sendSearchQuery('');
     searchEl.value='';searchFilter='';renderTree();treeEl.focus();e.preventDefault();
+  }else if(e.key==='Enter'&&searchFilter&&searchResultIds&&searchResultIds.length===1){
+    revealSearchResult(searchResultIds[0]);
+    e.preventDefault();
   }
 });
 
@@ -881,13 +977,53 @@ var flatRows=[];
 var vLastStart=-1,vLastEnd=-1;
 var scrollRaf=false;
 
+function buildSearchFlatRows(){
+  var matches=searchResultIds||[];
+  if(matches.length===0)return;
+  var visible={};
+  for(var i=0;i<matches.length;i++){
+    var cur=nodes[matches[i]];
+    var guard=0;
+    while(cur&&guard++<1000){
+      if(visible[cur.id])break;
+      visible[cur.id]=true;
+      if(!cur.parentId)break;
+      cur=nodes[cur.parentId];
+    }
+  }
+  var childMap={'':[]};
+  var linked={};
+  function link(parentId,id){
+    var key=parentId||'';
+    if(!childMap[key])childMap[key]=[];
+    if(linked[key+'\\n'+id])return;
+    linked[key+'\\n'+id]=true;
+    childMap[key].push(id);
+  }
+  function place(id){
+    if(!visible[id]||!nodes[id])return;
+    var pid=nodes[id].parentId||'';
+    if(pid&&!visible[pid])pid='';
+    link(pid,id);
+  }
+  var order=(searchTreeIds&&searchTreeIds.length)?searchTreeIds:matches;
+  for(var i=0;i<order.length;i++)place(order[i]);
+  for(var id in visible)place(id);
+  function walkSearch(parentId,depth){
+    var kids=childMap[parentId]||[];
+    for(var i=0;i<kids.length;i++){
+      var id=kids[i];
+      var hasKids=!!(childMap[id]&&childMap[id].length);
+      flatRows.push({id:id,depth:depth,searchHasChildren:hasKids});
+      walkSearch(id,depth+1);
+    }
+  }
+  walkSearch('',0);
+}
+
 function buildFlatRows(){
   flatRows=[];
-  if(searchFilter){
-    var ids=searchResultIds||[];
-    for(var i=0;i<ids.length;i++){if(nodes[ids[i]])flatRows.push({id:ids[i],depth:0})}
-    return;
-  }
+  if(searchFilter){buildSearchFlatRows();return}
   function walk(id,depth){
     var n=nodes[id];if(!n)return;
     flatRows.push({id:id,depth:depth});
@@ -921,21 +1057,25 @@ function renderViewport(){
   var h=[];
   for(var i=start;i<end;i++){
     var r=flatRows[i];
-    buildRowHtml(r.id,r.depth,i,h);
+    buildRowHtml(r,i,h);
   }
   rowsEl.innerHTML=h.join('');
   if(renameNodeId)afterRenameInputMount();
 }
 
-function buildRowHtml(id,depth,rowIndex,h){
+function buildRowHtml(row,rowIndex,h){
+  var id=row.id;
+  var depth=row.depth;
   var n=nodes[id];if(!n)return;
-  var has=n.hasChildren===true;
-  var exp=expandedIds.has(id);
-  var sel=selectedIds.indexOf(id)>=0;
-  var pad=depth*INDENT;
+  var inSearch=!!searchFilter;
+  var has=inSearch?row.searchHasChildren===true:n.hasChildren===true;
+  var exp=inSearch?has:expandedIds.has(id);
   var ac=has?(exp?' expanded':''):' leaf';
+  var sel=selectedIds.indexOf(id)>=0;
+  var preview=previewRevealNodeId===id;
+  var pad=depth*INDENT;
   var disabled=n.isScript&&n.disabled===true;
-  var rowClass='tree-row'+(sel?' selected':'')+(depth>0?' tree-indent-guides':'')+(disabled?' script-disabled':'');
+  var rowClass='tree-row'+(sel?' selected':'')+(preview?' previewed':'')+(depth>0?' tree-indent-guides':'')+(disabled?' script-disabled':'');
   var top=rowIndex*ROW_HEIGHT;
   var style='top:'+top+'px;height:'+ROW_HEIGHT+'px;padding-left:'+pad+'px';
   if(depth>0){
@@ -1004,7 +1144,8 @@ treeEl.addEventListener('click',function(e){
   var arrow=e.target.closest('.tree-arrow');
   if(arrow&&!arrow.classList.contains('leaf')){
     lastClickId=null;
-    toggleExpand(id);return;
+    if(!searchFilter)toggleExpand(id);
+    return;
   }
   if(e.target.closest('.tree-add-btn')){lastClickId=null;openQA(id,row);return}
   var now=Date.now();
@@ -1015,7 +1156,13 @@ treeEl.addEventListener('click',function(e){
     lastClickId=null;
     if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
     var node=nodes[id];
-    if(node&&node.hasChildren===true){toggleExpand(id)}
+    if(!searchFilter&&node&&node.hasChildren===true){toggleExpand(id)}
+    return;
+  }
+  if(searchFilter){
+    previewRevealNodeId=id;
+    pendingPreviewSearchQuery=null;pendingPreviewNodeId=null;
+    renderTree();
     return;
   }
   if(e.ctrlKey||e.metaKey){var i=selectedIds.indexOf(id);if(i>=0)selectedIds.splice(i,1);else selectedIds.push(id)}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -141,9 +141,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 		explorerViewProvider?.resetFullSyncStatus();
 		explorerViewProvider?.notifySnapshotReplaced();
 	}, (query, nodes) => {
-		if (explorerViewProvider?.getFullSyncStatus() !== "too_big") {
-			return;
-		}
 		const { added, needsRebuild } = explorerProvider.mergeSearchResults(nodes);
 		instanceHistory.updateNodeReferences((id: string) => explorerProvider.getNodeById(id));
 		if (needsRebuild) {

--- a/plugin/src/ServerStorage/Plugin/SearchIndex.luau
+++ b/plugin/src/ServerStorage/Plugin/SearchIndex.luau
@@ -1,0 +1,337 @@
+local Services = require(script.Parent.Shared.Services)
+local isValidInstance = require(script.Parent.Utils.isValidInstance)
+
+local BUILD_YIELD_EVERY = 2000
+local SEARCH_YIELD_SECONDS = 0.008
+local MAX_SEARCH_MATCHES = 500
+
+type SearchRecord = {
+	id: string,
+	instance: Instance,
+	parentId: string?,
+	nameLower: string,
+	classLower: string,
+	pathLower: string,
+	searchTextLower: string,
+	removed: boolean?,
+	nameConnection: RBXScriptConnection?,
+	ancestryConnection: RBXScriptConnection?,
+}
+
+type PartialCallback = ({ Instance }, boolean) -> ()
+type CancelCallback = () -> boolean
+
+local SearchIndex = {}
+
+local records: { SearchRecord } = {}
+local recordsById: { [string]: SearchRecord } = {}
+local rebuildToken = 0
+local building = false
+
+local function parentDebugId(instance: Instance): string?
+	local parent = instance.Parent
+	if parent and parent ~= game then
+		return parent:GetDebugId(0)
+	end
+	return nil
+end
+
+local function disconnectRecord(record: SearchRecord)
+	if record.nameConnection then
+		record.nameConnection:Disconnect()
+		record.nameConnection = nil
+	end
+	if record.ancestryConnection then
+		record.ancestryConnection:Disconnect()
+		record.ancestryConnection = nil
+	end
+end
+
+local function refreshRecord(record: SearchRecord)
+	local instance = record.instance
+	local parentId = parentDebugId(instance)
+	local parentRecord = if parentId then recordsById[parentId] else nil
+	local nameLower = string.lower(instance.Name)
+	local classLower = string.lower(instance.ClassName)
+	local pathLower = if parentRecord and not parentRecord.removed
+		then parentRecord.pathLower .. "." .. nameLower
+		else nameLower
+
+	record.parentId = parentId
+	record.nameLower = nameLower
+	record.classLower = classLower
+	record.pathLower = pathLower
+	record.searchTextLower = pathLower .. "\n" .. classLower
+end
+
+local removeSubtree
+local refreshSubtree
+
+local function addInstance(instance: Instance, assumeValid: boolean?): SearchRecord?
+	if not assumeValid and not isValidInstance(instance) then
+		return nil
+	end
+
+	local id = instance:GetDebugId(0)
+	local existing = recordsById[id]
+	if existing then
+		existing.removed = false
+		refreshRecord(existing)
+		return existing
+	end
+
+	local record: SearchRecord = {
+		id = id,
+		instance = instance,
+		parentId = nil,
+		nameLower = "",
+		classLower = "",
+		pathLower = "",
+		searchTextLower = "",
+	}
+
+	recordsById[id] = record
+	table.insert(records, record)
+	refreshRecord(record)
+
+	record.nameConnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
+		refreshSubtree(instance)
+	end)
+
+	record.ancestryConnection = instance.AncestryChanged:Connect(function()
+		if instance.Parent == nil or not isValidInstance(instance) then
+			removeSubtree(instance)
+			return
+		end
+		refreshSubtree(instance)
+	end)
+
+	return record
+end
+
+local function addSubtreeInternal(root: Instance, shouldCancel: CancelCallback?, assumeValid: boolean?): boolean
+	local stack: { Instance } = { root }
+	local visited = 0
+
+	while #stack > 0 do
+		if shouldCancel and shouldCancel() then
+			return false
+		end
+
+		local instance = stack[#stack]
+		stack[#stack] = nil
+
+		if assumeValid or isValidInstance(instance) then
+			addInstance(instance, true)
+			local children = instance:GetChildren()
+			for i = #children, 1, -1 do
+				stack[#stack + 1] = children[i]
+			end
+		end
+
+		visited += 1
+		if visited % BUILD_YIELD_EVERY == 0 then
+			task.wait()
+		end
+	end
+
+	return true
+end
+
+function refreshSubtree(root: Instance)
+	local stack: { Instance } = { root }
+	while #stack > 0 do
+		local instance = stack[#stack]
+		stack[#stack] = nil
+
+		local record = recordsById[instance:GetDebugId(0)]
+		if record and not record.removed then
+			refreshRecord(record)
+		end
+
+		for _, child in instance:GetChildren() do
+			if recordsById[child:GetDebugId(0)] then
+				stack[#stack + 1] = child
+			end
+		end
+	end
+end
+
+function removeSubtree(root: Instance)
+	local stack: { Instance } = { root }
+	while #stack > 0 do
+		local instance = stack[#stack]
+		stack[#stack] = nil
+
+		local id = instance:GetDebugId(0)
+		local record = recordsById[id]
+		if record then
+			record.removed = true
+			disconnectRecord(record)
+			recordsById[id] = nil
+		end
+
+		for _, child in instance:GetChildren() do
+			stack[#stack + 1] = child
+		end
+	end
+end
+
+local function clearRecords()
+	for _, record in records do
+		disconnectRecord(record)
+		record.removed = true
+	end
+	table.clear(records)
+	table.clear(recordsById)
+end
+
+function SearchIndex.clear()
+	rebuildToken += 1
+	building = false
+	clearRecords()
+end
+
+function SearchIndex.beginBuild(): number
+	rebuildToken += 1
+	local token = rebuildToken
+	building = true
+	clearRecords()
+	return token
+end
+
+function SearchIndex.addVisitedInstance(token: number, instance: Instance): boolean
+	if token ~= rebuildToken or not building then
+		return false
+	end
+	addInstance(instance, true)
+	return true
+end
+
+function SearchIndex.finishBuild(token: number): boolean
+	if token ~= rebuildToken then
+		return false
+	end
+	building = false
+	return true
+end
+
+function SearchIndex.cancelBuild(token: number)
+	if token ~= rebuildToken then
+		return
+	end
+	rebuildToken += 1
+	building = false
+	clearRecords()
+end
+
+function SearchIndex.rebuildAsync()
+	local token = SearchIndex.beginBuild()
+	task.spawn(function()
+		if token ~= rebuildToken then
+			return
+		end
+		for _, serviceName in Services do
+			if token ~= rebuildToken then
+				return
+			end
+			local service = game:GetService(serviceName)
+			local completed = addSubtreeInternal(service, function()
+				return token ~= rebuildToken
+			end, true)
+			if not completed then
+				return
+			end
+		end
+		SearchIndex.finishBuild(token)
+	end)
+end
+
+function SearchIndex.isReady(): boolean
+	return not building and #records > 0
+end
+
+function SearchIndex.isBuilding(): boolean
+	return building
+end
+
+function SearchIndex.addSubtree(root: Instance)
+	addSubtreeInternal(root, nil, true)
+end
+
+function SearchIndex.removeSubtree(root: Instance)
+	removeSubtree(root)
+end
+
+local function tokenize(lowercaseQuery: string): { string }
+	local tokens: { string } = {}
+	for token in string.gmatch(lowercaseQuery, "[^%s%.]+") do
+		table.insert(tokens, token)
+	end
+	return tokens
+end
+
+local function matches(record: SearchRecord, tokens: { string }): boolean
+	if record.removed or record.instance.Parent == nil then
+		return false
+	end
+
+	for _, token in tokens do
+		if string.find(record.searchTextLower, token, 1, true) == nil then
+			return false
+		end
+	end
+
+	return true
+end
+
+function SearchIndex.search(
+	lowercaseQuery: string,
+	shouldCancel: CancelCallback?,
+	onFirstResult: PartialCallback?
+): ({ Instance }, boolean, boolean)
+	local tokens = tokenize(lowercaseQuery)
+	local matched: { Instance } = {}
+	local truncated = false
+	local firstResultSent = false
+	local lastYieldAt = os.clock()
+
+	if #tokens == 0 then
+		return matched, false, false
+	end
+
+	local recordCount = #records
+	for index = 1, recordCount do
+		local record = records[index]
+		if not record then
+			continue
+		end
+		if shouldCancel and shouldCancel() then
+			return matched, truncated, true
+		end
+
+		if matches(record, tokens) then
+			matched[#matched + 1] = record.instance
+			if not firstResultSent and onFirstResult then
+				firstResultSent = true
+				onFirstResult({ record.instance }, false)
+			end
+			if #matched >= MAX_SEARCH_MATCHES then
+				truncated = true
+				break
+			end
+		end
+
+		if os.clock() - lastYieldAt >= SEARCH_YIELD_SECONDS then
+			task.wait()
+			lastYieldAt = os.clock()
+			if shouldCancel and shouldCancel() then
+				return matched, truncated, true
+			end
+		end
+	end
+
+	return matched, truncated, false
+end
+
+return SearchIndex

--- a/plugin/src/ServerStorage/Plugin/SerializeDatamodel.luau
+++ b/plugin/src/ServerStorage/Plugin/SerializeDatamodel.luau
@@ -23,6 +23,8 @@ type Snapshot = {
 	nodes: { Node },
 }
 
+type InstanceVisitCallback = (Instance) -> ()
+
 local YIELD_EVERY = 5000
 local MAX_DEPTH = 10000
 local MAX_NODES = 50000
@@ -47,7 +49,10 @@ local function makeNode(instance: Instance, parentId: string?): Node
 	return node
 end
 
-function SerializeDatamodel.serializeFull(maxNodes: number?): (Snapshot?, { [string]: Instance }?)
+function SerializeDatamodel.serializeFull(
+	maxNodes: number?,
+	onVisitedInstance: InstanceVisitCallback?
+): (Snapshot?, { [string]: Instance }?)
 	local limit: number = maxNodes or MAX_NODES
 	local nodes: { Node } = {}
 	local instanceMap: { [string]: Instance } = {}
@@ -86,6 +91,10 @@ function SerializeDatamodel.serializeFull(maxNodes: number?): (Snapshot?, { [str
 		instanceMap[id] = instance
 		nodes[#nodes + 1] = node
 		nodeCount += 1
+
+		if onVisitedInstance then
+			onVisitedInstance(instance)
+		end
 
 		if parentNode then
 			parentNode.children[#parentNode.children + 1] = id
@@ -160,16 +169,76 @@ function SerializeDatamodel.serializeShallow(instance: Instance, parentId: strin
 	return node
 end
 
+function SerializeDatamodel.serializeSearchMatches(
+	matches: { Instance },
+	maxNodes: number?
+): ({ Node }, { [string]: Instance }, boolean)
+	local limit = maxNodes or MAX_SEARCH_RESULTS
+	local nodes: { Node } = {}
+	local instanceMap: { [string]: Instance } = {}
+	local visited: { [string]: true } = {}
+	local truncated = false
+
+	local function include(instance: Instance): boolean
+		local id = instance:GetDebugId(0)
+		if visited[id] then
+			return true
+		end
+
+		if #nodes >= limit then
+			truncated = true
+			return false
+		end
+
+		local parent = instance.Parent
+		local parentId: string? = nil
+		if parent and parent ~= game then
+			if not include(parent) then
+				return false
+			end
+			parentId = parent:GetDebugId(0)
+		end
+
+		visited[id] = true
+
+		local node = SerializeDatamodel.serializeShallow(instance, parentId)
+
+		instanceMap[id] = instance
+		table.insert(nodes, node)
+		return true
+	end
+
+	for _, instance in matches do
+		if instance.Parent == nil then
+			continue
+		end
+		if not include(instance) then
+			break
+		end
+	end
+
+	return nodes, instanceMap, truncated
+end
+
 function SerializeDatamodel.serializeSearchResults(
 	lowercaseQuery: string,
-	candidates: { Instance }?
-): ({ Node }, { [string]: Instance }, boolean, { Instance })
+	candidates: { Instance }?,
+	shouldCancel: (() -> boolean)?
+): ({ Node }, { [string]: Instance }, boolean, { Instance }, boolean)
 	local nodes: { Node } = {}
 	local instanceMap: { [string]: Instance } = {}
 	local visited: { [string]: true } = {}
 	local matched: { Instance } = {}
 	local truncated = false
+	local canceled = false
 
+	local function shouldStop(): boolean
+		if shouldCancel and shouldCancel() then
+			canceled = true
+			return true
+		end
+		return false
+	end
 	local function include(instance: Instance): boolean
 		local id = instance:GetDebugId(0)
 		if visited[id] then
@@ -247,6 +316,9 @@ function SerializeDatamodel.serializeSearchResults(
 
 	local considered = 0
 	local function consider(instance: Instance): boolean
+		if shouldStop() then
+			return false
+		end
 		if #nodes >= MAX_SEARCH_RESULTS then
 			truncated = true
 			return false
@@ -254,6 +326,9 @@ function SerializeDatamodel.serializeSearchResults(
 		considered += 1
 		if considered % YIELD_EVERY == 0 then
 			task.wait()
+			if shouldStop() then
+				return false
+			end
 		end
 		if instance.Parent == nil then
 			return true
@@ -282,13 +357,13 @@ function SerializeDatamodel.serializeSearchResults(
 					break
 				end
 			end
-			if truncated then
+			if truncated or canceled then
 				break
 			end
 		end
 	end
 
-	return nodes, instanceMap, truncated, matched
+	return nodes, instanceMap, truncated, matched, canceled
 end
 
 return SerializeDatamodel

--- a/plugin/src/ServerStorage/Plugin/States/Connected.luau
+++ b/plugin/src/ServerStorage/Plugin/States/Connected.luau
@@ -12,6 +12,7 @@ local ButtonInstance = SharedFolder.ButtonInstance
 local Icons = SharedFolder.Icons
 local State = SharedFolder.State
 local Operations = require(script.Parent.Parent.Operations)
+local SearchIndex = require(script.Parent.Parent.SearchIndex)
 
 type Client = WebSocketClient.WebSocketClientInstance
 
@@ -37,6 +38,7 @@ local lastSearchMatched: { Instance } = {}
 local lastSearchTruncated = false
 local searchCacheDirty = false
 local searchGeneration = 0
+local queuedSearchPromise: any = nil
 
 local lastAckTime = 0
 local initialSyncComplete = false
@@ -274,11 +276,18 @@ local function _sendSnapshot(client: Client, full: boolean?)
 	end
 
 	local snapshot, instanceMap
+	local searchBuildToken: number? = nil
 	if full then
-		snapshot, instanceMap = SerializeDatamodel.serializeFull(MAX_FULL_SYNC_NODES)
+		local token = SearchIndex.beginBuild()
+		searchBuildToken = token
+		snapshot, instanceMap = SerializeDatamodel.serializeFull(MAX_FULL_SYNC_NODES, function(instance)
+			SearchIndex.addVisitedInstance(token, instance)
+		end)
 		if not snapshot or not instanceMap then
+			SearchIndex.cancelBuild(token)
 			fullSyncMode = false
 			_sendSnapshotTooBig(client)
+			SearchIndex.rebuildAsync()
 			return
 		end
 	else
@@ -330,6 +339,9 @@ local function _sendSnapshot(client: Client, full: boolean?)
 			isFull = full == true,
 		})
 	then
+		if searchBuildToken then
+			SearchIndex.cancelBuild(searchBuildToken)
+		end
 		warn("[verde] failed to send explorer_snapshot (will retry)")
 		if not snapshotPromise then
 			snapshotPromise = Promise.delay(0.1):andThen(function()
@@ -342,6 +354,11 @@ local function _sendSnapshot(client: Client, full: boolean?)
 
 	lastAckTime = tick()
 	initialSyncComplete = true
+	if searchBuildToken then
+		SearchIndex.finishBuild(searchBuildToken)
+	else
+		SearchIndex.rebuildAsync()
+	end
 end
 
 local function _sendOperationResult(
@@ -486,6 +503,10 @@ local function _handleRequestSearch(client: Client, query: string?)
 
 	local trimmed = query and string.gsub(query, "^%s*(.-)%s*$", "%1") or ""
 	if #trimmed < 2 then
+		if queuedSearchPromise then
+			queuedSearchPromise:cancel()
+			queuedSearchPromise = nil
+		end
 		_releaseSearchGrafted(nil)
 		_resetSearchCache()
 		return
@@ -493,24 +514,121 @@ local function _handleRequestSearch(client: Client, query: string?)
 
 	local lowercase = string.lower(trimmed)
 
-	local candidates: { Instance }? = nil
-	if
-		fullSyncMode
-		and lastSearchLower ~= ""
-		and not lastSearchTruncated
-		and not searchCacheDirty
-		and #lowercase >= #lastSearchLower
-		and string.sub(lowercase, 1, #lastSearchLower) == lastSearchLower
-	then
-		candidates = lastSearchMatched
-	end
-
 	searchCacheDirty = false
 
-	local nodes, resultInstanceMap, truncated, matched =
-		SerializeDatamodel.serializeSearchResults(lowercase, candidates)
+	local function shouldCancel(): boolean
+		return generation ~= searchGeneration or not client.connected
+	end
 
-	if generation ~= searchGeneration then
+	local function sendMatches(
+		matches: { Instance },
+		partial: boolean,
+		searchTruncated: boolean,
+		rebuildingIndex: boolean?
+	)
+		if shouldCancel() then
+			return
+		end
+
+		local nodes, resultInstanceMap, nodeTruncated =
+			SerializeDatamodel.serializeSearchMatches(matches)
+		local truncated = searchTruncated or nodeTruncated
+
+		if shouldCancel() then
+			return
+		end
+
+		_releaseSearchGrafted(resultInstanceMap)
+		for id, instance in resultInstanceMap do
+			_registerAndTrack(client, id, instance)
+			if not loadedParents[id] then
+				searchGraftedIds[id] = true
+			end
+		end
+
+		local message: any = {
+			type = "search_result",
+			query = trimmed,
+			nodes = nodes,
+			truncated = truncated,
+			partial = partial,
+		}
+		if rebuildingIndex then
+			message.rebuildingIndex = true
+		end
+		_encodeAndSend(client, message)
+	end
+
+	local function retryWhenIndexReady()
+		if queuedSearchPromise then
+			queuedSearchPromise:cancel()
+		end
+		queuedSearchPromise = Promise.delay(0.1):andThen(function()
+			queuedSearchPromise = nil
+			if generation ~= searchGeneration or not client.connected then
+				return
+			end
+			if SearchIndex.isBuilding() then
+				retryWhenIndexReady()
+			else
+				_handleRequestSearch(client, trimmed)
+			end
+		end)
+	end
+
+	if not SearchIndex.isReady() then
+		if SearchIndex.isBuilding() then
+			local partialMatched, partialTruncated, partialCanceled =
+				SearchIndex.search(lowercase, shouldCancel, function(firstMatches, partialTruncated)
+					sendMatches(firstMatches, true, partialTruncated, true)
+				end)
+			if partialCanceled or shouldCancel() then
+				return
+			end
+
+			lastSearchLower = lowercase
+			lastSearchMatched = partialMatched
+			lastSearchTruncated = partialTruncated
+			sendMatches(partialMatched, true, partialTruncated, true)
+			retryWhenIndexReady()
+			return
+		end
+
+		local nodes, resultInstanceMap, truncated, matched, canceled =
+			SerializeDatamodel.serializeSearchResults(lowercase, nil, shouldCancel)
+
+		if canceled or shouldCancel() then
+			return
+		end
+
+		lastSearchLower = lowercase
+		lastSearchMatched = matched
+		lastSearchTruncated = truncated
+
+		_releaseSearchGrafted(resultInstanceMap)
+		for id, instance in resultInstanceMap do
+			_registerAndTrack(client, id, instance)
+			if not loadedParents[id] then
+				searchGraftedIds[id] = true
+			end
+		end
+
+		_encodeAndSend(client, {
+			type = "search_result",
+			query = trimmed,
+			nodes = nodes,
+			truncated = truncated,
+			partial = false,
+			rebuildingIndex = SearchIndex.isBuilding(),
+		})
+		return
+	end
+
+	local matched, truncated, canceled = SearchIndex.search(lowercase, shouldCancel, function(firstMatches, partialTruncated)
+		sendMatches(firstMatches, true, partialTruncated)
+	end)
+
+	if canceled or shouldCancel() then
 		return
 	end
 
@@ -518,20 +636,7 @@ local function _handleRequestSearch(client: Client, query: string?)
 	lastSearchMatched = matched
 	lastSearchTruncated = truncated
 
-	_releaseSearchGrafted(resultInstanceMap)
-	for id, instance in resultInstanceMap do
-		_registerAndTrack(client, id, instance)
-		if not loadedParents[id] then
-			searchGraftedIds[id] = true
-		end
-	end
-
-	_encodeAndSend(client, {
-		type = "search_result",
-		query = trimmed,
-		nodes = nodes,
-		truncated = truncated,
-	})
+	sendMatches(matched, false, truncated)
 end
 
 local function _handleRequestChildren(client: Client, parentIds: { string })
@@ -542,7 +647,6 @@ local function _handleRequestChildren(client: Client, parentIds: { string })
 	for _, parentId in parentIds do
 		local parentInstance = InstanceMap[parentId]
 		if not parentInstance then
-			warn("[verde] request_children for unknown parent:", parentId)
 			continue
 		end
 
@@ -675,6 +779,7 @@ connected.onEnter = function(transitionTo: (string) -> (), client: WebSocketClie
 			end
 
 			searchCacheDirty = true
+			SearchIndex.addSubtree(descendant)
 
 			if not _shouldSyncNewDescendant(descendant) then
 				local parentId = _parentDebugId(descendant)
@@ -713,6 +818,7 @@ connected.onEnter = function(transitionTo: (string) -> (), client: WebSocketClie
 		connections,
 		game.DescendantRemoving:Connect(function(descendant)
 			local instanceId = descendant:GetDebugId(0)
+			SearchIndex.removeSubtree(descendant)
 			if not InstanceMap[instanceId] then
 				return
 			end
@@ -773,6 +879,11 @@ connected.onExit = function()
 		propertyUpdatePromise:cancel()
 	end
 
+	if queuedSearchPromise then
+		queuedSearchPromise:cancel()
+		queuedSearchPromise = nil
+	end
+
 	table.clear(connections)
 	table.clear(pendingOps)
 	table.clear(InstanceMap)
@@ -781,6 +892,7 @@ connected.onExit = function()
 	end
 	table.clear(searchGraftedIds)
 	_resetSearchCache()
+	SearchIndex.clear()
 	fullSyncMode = false
 	lastAckTime = tick()
 	initialSyncComplete = false


### PR DESCRIPTION
## Summary
- Render explorer search as a pruned matches-plus-ancestors tree without auto-loading unrelated branches.
- Suppress stale `request_children` warning spam for released parents.
- Make search-index builds reusable/searchable during cold start and full snapshots.

## Verification
- `npm run compile` in `extension/`
- targeted webview syntax/search-tree checks
- `stylua --check src/ServerStorage/Plugin/SearchIndex.luau`
- `stylua --check` parsed touched Luau files; remaining output is formatting diffs in existing style