### PR TITLE
feat(extension): add single-click to open functionality and improve properties view handling

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -64,6 +64,11 @@
           "type": "boolean",
           "default": false,
           "description": "Allow third-party extensions to execute Luau code inside Roblox Studio via Verde's API. Also requires the workspace to be trusted; untrusted workspaces always refuse. Each extension is prompted for consent on first use. Disable to block all extension-initiated scripting."
+        },
+        "verde.singleClickToOpen": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, single-clicking an instance opens it immediately. Scripts open in the editor and other instances open in the Properties panel. When disabled, those actions require a double-click."
         }
       }
     },

--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -34,6 +34,7 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
   private webviewView: vscode.WebviewView | undefined;
   private selectedIds: string[] = [];
   private selectionListeners: ((nodes: Node[]) => void)[] = [];
+  private activationListeners: ((node: Node) => void)[] = [];
   private knownParentIds: Set<string> = new Set();
   private fullSyncStatus: FullSyncStatus = "unknown";
   private pendingSearchQuery: string | null = null;
@@ -227,6 +228,10 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     this.selectionListeners.push(listener);
   }
 
+  public onNodeActivated(listener: (node: Node) => void): void {
+    this.activationListeners.push(listener);
+  }
+
   public getSelection(): Node[] {
     return this.selectedIds
       .map(id => this.explorerProvider.getNodeById(id))
@@ -319,6 +324,9 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
       if (e.affectsConfiguration("verde.coloredSelection") || e.affectsConfiguration("verde.coloredSelectionColor")) {
         this.pushSelectionColor();
       }
+      if (e.affectsConfiguration("verde.singleClickToOpen")) {
+        this.pushInteractionSettings();
+      }
     });
     const assetBase = webviewView.webview.asWebviewUri(
       vscode.Uri.joinPath(this.extensionUri, "assets")
@@ -327,6 +335,7 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     this.pushSnapshot();
     this.pushSyncStatus();
     this.pushSelectionColor();
+    this.pushInteractionSettings();
   }
 
   public refreshWebviewHtml(): void {
@@ -417,6 +426,14 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
+  private pushInteractionSettings(): void {
+    const cfg = vscode.workspace.getConfiguration("verde");
+    this.post({
+      type: "updateInteractionSettings",
+      singleClickToOpen: cfg.get<boolean>("singleClickToOpen", false),
+    });
+  }
+
   private serializeChildren(parentId: string | null): WebviewNode[] {
     const children = this.explorerProvider.getSortedChildren(parentId);
     return children.map(n => this.serializeNode(n));
@@ -459,12 +476,23 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     for (const cb of this.selectionListeners) cb(nodes);
   }
 
+  private fireNodeActivated(node: Node): void {
+    for (const cb of this.activationListeners) cb(node);
+  }
+
   private onMessage(msg: any): void {
     switch (msg.type) {
       case "selectionChanged":
         this.selectedIds = msg.nodeIds ?? [];
         this.fireSelectionChanged();
         break;
+      case "nodeActivated": {
+        const node = this.explorerProvider.getNodeById(msg.nodeId);
+        if (node) {
+          this.fireNodeActivated(node);
+        }
+        break;
+      }
       case "requestChildren": {
         const parentId = typeof msg.nodeId === "string" ? msg.nodeId : "";
         const key = parentId === "" ? null : parentId;
@@ -712,6 +740,7 @@ var SLOW_CLICK_RENAME_DELAY=800;
 var DBLCLICK_THRESHOLD=400;
 var slowClickTimer=null;
 var lastClickTime=0,lastClickId=null;
+var singleClickToOpen=false;
 
 var expandedIds=new Set();
 var dragSourceId=null;
@@ -876,6 +905,9 @@ window.addEventListener('message',function(e){
           so.textContent='.tree-row.selected{background:'+m.color+' !important}#tree:focus-within .tree-row.selected{background:'+m.color+' !important}';
         }else{so.textContent=''}
       }
+      break;
+    case 'updateInteractionSettings':
+      singleClickToOpen=!!m.singleClickToOpen;
       break;
     case 'collapseAll':
       if(localSyncStatus!=='full'&&!searchFilter){
@@ -1154,6 +1186,7 @@ treeEl.addEventListener('click',function(e){
   lastClickId=id;
   if(isDbl){
     lastClickId=null;
+    if(!singleClickToOpen){vscode.postMessage({type:'nodeActivated',nodeId:id})}
     if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id});return}
     var node=nodes[id];
     if(!searchFilter&&node&&node.hasChildren===true){toggleExpand(id)}
@@ -1175,6 +1208,10 @@ treeEl.addEventListener('click',function(e){
   }
   updateSelVis();
   vscode.postMessage({type:'selectionChanged',nodeIds:selectedIds.slice()});
+  if(singleClickToOpen&&!e.ctrlKey&&!e.metaKey&&selectedIds.length===1&&selectedIds[0]===id){
+    vscode.postMessage({type:'nodeActivated',nodeId:id});
+    if(row.dataset.s==='1'){vscode.postMessage({type:'scriptActivated',nodeId:id})}
+  }
 });
 
 treeEl.addEventListener('dblclick',function(e){e.preventDefault()});

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,6 +34,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 	const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri || context.extensionUri;
 	sourcemapParser = new SourcemapParser(workspaceRoot);
 	instanceHistory = new InstanceHistory(10);
+	const showNodeInProperties = (node: Node) => {
+		propertiesViewProvider.show(node);
+
+		const instancePath = getInstancePath(node);
+		instanceHistory.add(node, instancePath);
+	};
 
 	const revealOnNextSnapshot = (
 		editorUriToMatch: string | null,
@@ -209,13 +215,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 	);
 
 	explorerViewProvider.onSelectionChanged((selection) => {
-		if (selection.length === 1) {
-			const node = selection[0];
-			propertiesViewProvider.show(node);
-
-			const instancePath = getInstancePath(node);
-			instanceHistory.add(node, instancePath);
+		if (selection.length !== 1) {
+			return;
 		}
+
+		if (!vscode.workspace.getConfiguration('verde').get<boolean>('singleClickToOpen', false)) {
+			return;
+		}
+
+		showNodeInProperties(selection[0]);
+	});
+
+	explorerViewProvider.onNodeActivated((node) => {
+		showNodeInProperties(node);
 	});
 
 	context.subscriptions.push(

--- a/extension/src/propertiesViewProvider.ts
+++ b/extension/src/propertiesViewProvider.ts
@@ -106,6 +106,7 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
 			this.separatePanel.title = `Properties - ${this.currentNodeClassName} - ${this.currentNodeName}`;
 			this.loadPropertiesForPanel(this.separatePanel.webview);
 		} else if (this.webviewView) {
+			this.webviewView.show?.(true);
 			setTimeout(() => {
 				this.loadProperties();
 			}, 100);


### PR DESCRIPTION
Adds support for `verde.singleClickToOpen` in the explorer. When enabled, single-click opens scripts in the editor and other instances in the Properties panel; otherwise those actions still require double click. Also updates the Properties view reveal behavior and setting description to match.