### PR TITLE
feat(extension): add support for custom icons and improve icon handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Verde can be used either with a dedicated sync tool (Like Rojo/Argon/Azul) or wi
 * `verde.port`: Port for the WebSocket server - defaults to 9000
 * `verde.host`: Host IP address for the WebSocket server - defaults to "localhost"
 * `verde.autoStart`: Automatically start the server when the extension activates - defaults to true
+* `verde.iconDirectory`: Optional absolute or workspace-relative directory containing `ClassName.png` overrides. You can point either to the icon folder itself or to a parent pack root that contains `RobloxCustom/instance/16x/200`. Missing icons still use Verde's bundled assets.
 
 ## Usage
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -69,6 +69,11 @@
           "type": "boolean",
           "default": false,
           "description": "When enabled, single-clicking an instance opens it immediately. Scripts open in the editor and other instances open in the Properties panel. When disabled, those actions require a double-click."
+        },
+        "verde.iconDirectory": {
+          "type": "string",
+          "default": "",
+          "description": "Optional absolute path or workspace-relative path to a directory of Roblox class icon PNGs. You can point either to the icon folder itself or to a parent pack root that contains RobloxCustom/instance/16x/200. Matching files override bundled icons, and missing files fall back to Verde's built-in icons."
         }
       }
     },

--- a/extension/src/explorerViewProvider.ts
+++ b/extension/src/explorerViewProvider.ts
@@ -6,6 +6,7 @@ import { getClassNames } from "./robloxClasses";
 import { isScriptClass, scriptIconClass, buildDottedPath } from "./utils";
 import { getThemeCssBlock, getThemeScriptBlock, getThemeStyleAttribute } from "./webviewTheme";
 import { ContextMenuRegistry } from "./contextMenuRegistry";
+import { getBundledIconsUri, getCustomIconClassNames, getCustomIconsUri } from "./iconResolver";
 
 type WebviewNode = {
   id: string;
@@ -311,10 +312,13 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken,
   ): void {
     this.webviewView = webviewView;
+    const bundledIconsUri = getBundledIconsUri(this.extensionUri);
+    const customIconsUri = getCustomIconsUri();
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [
-        vscode.Uri.joinPath(this.extensionUri, "assets"),
+        bundledIconsUri,
+        ...(customIconsUri ? [customIconsUri] : []),
         vscode.Uri.joinPath(this.extensionUri, "resources"),
       ],
     };
@@ -328,10 +332,16 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
         this.pushInteractionSettings();
       }
     });
-    const assetBase = webviewView.webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, "assets")
-    ).toString();
-    webviewView.webview.html = this.buildHtml(webviewView.webview, assetBase);
+    const assetBase = webviewView.webview.asWebviewUri(bundledIconsUri).toString();
+    const customAssetBase = customIconsUri
+      ? webviewView.webview.asWebviewUri(customIconsUri).toString()
+      : null;
+    webviewView.webview.html = this.buildHtml(
+      webviewView.webview,
+      assetBase,
+      customAssetBase,
+      Array.from(getCustomIconClassNames()),
+    );
     this.pushSnapshot();
     this.pushSyncStatus();
     this.pushSelectionColor();
@@ -340,10 +350,26 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
 
   public refreshWebviewHtml(): void {
     if (!this.webviewView) return;
-    const assetBase = this.webviewView.webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, "assets")
-    ).toString();
-    this.webviewView.webview.html = this.buildHtml(this.webviewView.webview, assetBase);
+    const bundledIconsUri = getBundledIconsUri(this.extensionUri);
+    const customIconsUri = getCustomIconsUri();
+    this.webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        bundledIconsUri,
+        ...(customIconsUri ? [customIconsUri] : []),
+        vscode.Uri.joinPath(this.extensionUri, "resources"),
+      ],
+    };
+    const assetBase = this.webviewView.webview.asWebviewUri(bundledIconsUri).toString();
+    const customAssetBase = customIconsUri
+      ? this.webviewView.webview.asWebviewUri(customIconsUri).toString()
+      : null;
+    this.webviewView.webview.html = this.buildHtml(
+      this.webviewView.webview,
+      assetBase,
+      customAssetBase,
+      Array.from(getCustomIconClassNames()),
+    );
     this.pushSnapshot();
     this.pushSyncStatus();
   }
@@ -636,7 +662,12 @@ export class ExplorerViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private buildHtml(webview: vscode.Webview, assetBase: string): string {
+  private buildHtml(
+    webview: vscode.Webview,
+    assetBase: string,
+    customAssetBase: string | null,
+    customIconNames: string[],
+  ): string {
     const csp = webview.cspSource;
     const themeStyle = getThemeStyleAttribute();
     const themeCss = getThemeCssBlock();
@@ -724,6 +755,12 @@ ${themeScript}
 <script>
 (function(){
 var ASSET=${JSON.stringify(assetBase)};
+var CUSTOM_ASSET=${JSON.stringify(customAssetBase)};
+var CUSTOM_ICON_NAMES=new Set(${JSON.stringify(customIconNames)});
+function iconSrc(name){
+  if(CUSTOM_ASSET&&CUSTOM_ICON_NAMES.has(name))return CUSTOM_ASSET+'/'+name+'.png';
+  return ASSET+'/'+name+'.png';
+}
 var CLASSES=${JSON.stringify(getClassNames())};
 var vscode=acquireVsCodeApi();
 
@@ -1121,7 +1158,8 @@ function buildRowHtml(row,rowIndex,h){
   }
   h.push('<div class="'+rowClass+'" data-id="'+id+'" data-s="'+(n.isScript?1:0)+'" data-disabled="'+(disabled?1:0)+'" draggable="'+(depth>0?'true':'false')+'" style="'+style+'">');
   h.push('<span class="tree-arrow'+ac+'"></span>');
-  h.push('<img class="tree-icon" src="'+ASSET+'/'+esc(n.iconClassName||n.className)+'.png"'+(disabled?' style="opacity:.45"':'')+'>');
+  var iconName=esc(n.iconClassName||n.className);
+  h.push('<img class="tree-icon" src="'+iconSrc(iconName)+'"'+(disabled?' style="opacity:.45"':'')+'>');
   h.push('<span class="tree-name-group">');
   if(id===renameNodeId){
     h.push('<input class="tree-rename-input" type="text" value="'+esc(n.name)+'" data-id="'+id+'">');
@@ -1343,7 +1381,8 @@ function renderQA(){
   for(var i=0;i<qaFiltered.length;i++){
     var c=qaFiltered[i];
     html+='<div class="qa-item'+(i===qaIdx?' selected':'')+'" data-cls="'+esc(c)+'">';
-    html+='<img class="qa-icon" src="'+ASSET+'/'+esc(c)+'.png">';
+    var iconName=esc(c);
+    html+='<img class="qa-icon" src="'+iconSrc(iconName)+'">';
     html+='<span>'+esc(c)+'</span></div>';
   }
   qaListEl.innerHTML=html;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -10,6 +10,7 @@ import { InstanceHistory, HistoryEntry } from "./instanceHistory";
 import { ContextMenuRegistry } from "./contextMenuRegistry";
 import { LuauExecutionService } from "./luauExecutionService";
 import { VerdeApi } from "./api";
+import { resolveIconUri } from "./iconResolver";
 
 import * as fzy from "fzy.js";
 
@@ -85,42 +86,42 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 		});
 	};
 
-	const buildQuickPickItem = (node: Node, detail: string): vscode.QuickPickItem & { node: Node } => {
+	const buildQuickPickItem = async (node: Node, detail: string): Promise<vscode.QuickPickItem & { node: Node }> => {
 		return {
 			label: node.name,
 			description: node.className,
 			detail,
-			iconPath: vscode.Uri.joinPath(context.extensionUri, "assets", `${node.className}.png`),
+			iconPath: await resolveIconUri(context.extensionUri, node.className),
 			alwaysShow: true,
 			node
 		};
 	};
 
-	const addNodesToQuickPickCache = (nodes: Node[], pathCache: Map<string, string>) => {
+	const addNodesToQuickPickCache = async (nodes: Node[], pathCache: Map<string, string>) => {
 		for (const node of nodes) {
 			const detail = dottedPath(node, pathCache);
 			cachedSearchStrings.push(detail);
-			cachedQuickPickItems.push(buildQuickPickItem(node, detail));
+			cachedQuickPickItems.push(await buildQuickPickItem(node, detail));
 		}
 	};
 
-	const rebuildQuickPickCache = () => {
+	const rebuildQuickPickCache = async () => {
 		cachedSearchStrings = [];
 		cachedQuickPickItems = [];
-		addNodesToQuickPickCache(explorerProvider.getAllNodes(), new Map<string, string>());
+		await addNodesToQuickPickCache(explorerProvider.getAllNodes(), new Map<string, string>());
 		if (onQuickPickCacheRebuilt) onQuickPickCacheRebuilt();
 	};
 
-	const appendQuickPickCache = (added: Node[]) => {
+	const appendQuickPickCache = async (added: Node[]) => {
 		if (added.length === 0) return;
-		addNodesToQuickPickCache(added, new Map<string, string>());
+		await addNodesToQuickPickCache(added, new Map<string, string>());
 		if (onQuickPickCacheRebuilt) onQuickPickCacheRebuilt();
 	};
 
 	backend = new VerdeBackend(outputChannel, statusBarItem, (snapshot, isFull) => {
 		explorerProvider.setSnapshot(snapshot, isFull);
 		instanceHistory.updateNodeReferences((id: string) => explorerProvider.getNodeById(id));
-		rebuildQuickPickCache();
+		void rebuildQuickPickCache();
 		explorerViewProvider?.notifySnapshotReplaced();
 		if (isFull) {
 			explorerViewProvider?.markFullSyncSucceeded();
@@ -135,9 +136,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 		}
 		instanceHistory.updateNodeReferences((id: string) => explorerProvider.getNodeById(id));
 		if (needsRebuild) {
-			rebuildQuickPickCache();
+			void rebuildQuickPickCache();
 		} else if (added.length > 0) {
-			appendQuickPickCache(added);
+			void appendQuickPickCache(added);
 		}
 	}, () => {
 		explorerProvider.setSnapshot({ nodes: [], rootIds: [] });
@@ -150,9 +151,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 		const { added, needsRebuild } = explorerProvider.mergeSearchResults(nodes);
 		instanceHistory.updateNodeReferences((id: string) => explorerProvider.getNodeById(id));
 		if (needsRebuild) {
-			rebuildQuickPickCache();
+			void rebuildQuickPickCache();
 		} else {
-			appendQuickPickCache(added);
+			void appendQuickPickCache(added);
 		}
 		explorerViewProvider?.handleSearchResults(query, nodes);
 	}, () => {
@@ -211,6 +212,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 		vscode.window.onDidChangeActiveColorTheme(() => {
 			explorerViewProvider.refreshWebviewHtml();
 			propertiesViewProvider.refreshWebviewHtml();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration((event) => {
+			if (!event.affectsConfiguration("verde.iconDirectory")) {
+				return;
+			}
+
+			explorerViewProvider.refreshWebviewHtml();
+			void initClassNames(context, () => explorerViewProvider.postClassNames());
+			void rebuildQuickPickCache();
 		})
 	);
 
@@ -731,10 +744,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 				return;
 			}
 
-			const quickPickItems = getClassNames().map(className => ({
+			const quickPickItems = await Promise.all(getClassNames().map(async className => ({
 				label: className,
-				iconPath: vscode.Uri.joinPath(context.extensionUri, "assets", `${className}.png`)
-			}));
+				iconPath: await resolveIconUri(context.extensionUri, className)
+			})));
 
 			const selectedItem = await vscode.window.showQuickPick(
 				quickPickItems,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -10,7 +10,7 @@ import { InstanceHistory, HistoryEntry } from "./instanceHistory";
 import { ContextMenuRegistry } from "./contextMenuRegistry";
 import { LuauExecutionService } from "./luauExecutionService";
 import { VerdeApi } from "./api";
-import { resolveIconUri } from "./iconResolver";
+import { invalidateCustomIconCache, resolveIconUri } from "./iconResolver";
 
 import * as fzy from "fzy.js";
 
@@ -221,6 +221,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<VerdeA
 				return;
 			}
 
+			invalidateCustomIconCache();
 			explorerViewProvider.refreshWebviewHtml();
 			void initClassNames(context, () => explorerViewProvider.postClassNames());
 			void rebuildQuickPickCache();

--- a/extension/src/iconResolver.ts
+++ b/extension/src/iconResolver.ts
@@ -8,6 +8,15 @@ const ICON_DIRECTORY_CANDIDATE_SUFFIXES = [
     "",
 ];
 
+type CustomIconCache = {
+    resolvedDirectoryPath?: string;
+    iconsUri?: vscode.Uri;
+    iconClassNames: Set<string>;
+};
+
+let customIconCacheKey: string | undefined;
+let customIconCache: CustomIconCache | undefined;
+
 function getConfiguredIconDirectory(): string | undefined {
     const configured = vscode.workspace
         .getConfiguration("verde")
@@ -32,15 +41,6 @@ function resolveIconDirectoryPath(): string | undefined {
 
     const workspaceBase = getWorkspaceBasePath();
     return workspaceBase ? path.resolve(workspaceBase, configured) : undefined;
-}
-
-async function fileExists(uri: vscode.Uri): Promise<boolean> {
-    try {
-        await vscode.workspace.fs.stat(uri);
-        return true;
-    } catch {
-        return false;
-    }
 }
 
 function directoryExists(fsPath: string): boolean {
@@ -84,29 +84,52 @@ export function getBundledIconsUri(extensionUri: vscode.Uri): vscode.Uri {
     return vscode.Uri.joinPath(extensionUri, "assets");
 }
 
+function getCustomIconCacheKey(): string | undefined {
+    const resolvedDirectoryPath = resolveIconDirectoryPath();
+    return resolvedDirectoryPath ? path.normalize(resolvedDirectoryPath) : undefined;
+}
+
+function getCustomIconCache(): CustomIconCache {
+    const cacheKey = getCustomIconCacheKey();
+    if (customIconCache && customIconCacheKey === cacheKey) {
+        return customIconCache;
+    }
+
+    const resolvedDirectoryPath = resolveExistingIconDirectory(cacheKey);
+    const iconClassNames = resolvedDirectoryPath
+        ? readPngBaseNames(resolvedDirectoryPath)
+        : new Set<string>();
+
+    customIconCacheKey = cacheKey;
+    customIconCache = {
+        resolvedDirectoryPath,
+        iconsUri: resolvedDirectoryPath ? vscode.Uri.file(resolvedDirectoryPath) : undefined,
+        iconClassNames,
+    };
+
+    return customIconCache;
+}
+
+export function invalidateCustomIconCache(): void {
+    customIconCacheKey = undefined;
+    customIconCache = undefined;
+}
+
 export function getCustomIconsUri(): vscode.Uri | undefined {
-    const resolved = resolveExistingIconDirectory(resolveIconDirectoryPath());
-    return resolved ? vscode.Uri.file(resolved) : undefined;
+    return getCustomIconCache().iconsUri;
 }
 
 export function getCustomIconClassNames(): Set<string> {
-    const resolved = resolveExistingIconDirectory(resolveIconDirectoryPath());
-    if (!resolved) {
-        return new Set<string>();
-    }
-    return readPngBaseNames(resolved);
+    return new Set(getCustomIconCache().iconClassNames);
 }
 
 export async function resolveIconUri(
     extensionUri: vscode.Uri,
     iconName: string,
 ): Promise<vscode.Uri> {
-    const customIconsUri = getCustomIconsUri();
-    if (customIconsUri) {
-        const customIconUri = vscode.Uri.joinPath(customIconsUri, `${iconName}.png`);
-        if (await fileExists(customIconUri)) {
-            return customIconUri;
-        }
+    const customIconCache = getCustomIconCache();
+    if (customIconCache.iconsUri && customIconCache.iconClassNames.has(iconName)) {
+        return vscode.Uri.joinPath(customIconCache.iconsUri, `${iconName}.png`);
     }
 
     return vscode.Uri.joinPath(getBundledIconsUri(extensionUri), `${iconName}.png`);
@@ -116,7 +139,8 @@ export async function getAvailableIconClassNames(
     extensionUri: vscode.Uri,
 ): Promise<Set<string>> {
     const names = new Set<string>();
-    const sources = [getBundledIconsUri(extensionUri), getCustomIconsUri()].filter(
+    const customIconCache = getCustomIconCache();
+    const sources = [getBundledIconsUri(extensionUri)].filter(
         (uri): uri is vscode.Uri => uri !== undefined,
     );
 
@@ -131,6 +155,10 @@ export async function getAvailableIconClassNames(
         } catch {
             // Ignore missing or unreadable custom icon directories and fall back to bundled icons.
         }
+    }
+
+    for (const name of customIconCache.iconClassNames) {
+        names.add(name);
     }
 
     return names;

--- a/extension/src/iconResolver.ts
+++ b/extension/src/iconResolver.ts
@@ -1,0 +1,137 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+const ICON_DIRECTORY_SETTING = "iconDirectory";
+const ICON_DIRECTORY_CANDIDATE_SUFFIXES = [
+    path.join("RobloxCustom", "instance", "16x", "200"),
+    "",
+];
+
+function getConfiguredIconDirectory(): string | undefined {
+    const configured = vscode.workspace
+        .getConfiguration("verde")
+        .get<string>(ICON_DIRECTORY_SETTING, "")
+        .trim();
+    return configured || undefined;
+}
+
+function getWorkspaceBasePath(): string | undefined {
+    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+function resolveIconDirectoryPath(): string | undefined {
+    const configured = getConfiguredIconDirectory();
+    if (!configured) {
+        return undefined;
+    }
+
+    if (path.isAbsolute(configured)) {
+        return configured;
+    }
+
+    const workspaceBase = getWorkspaceBasePath();
+    return workspaceBase ? path.resolve(workspaceBase, configured) : undefined;
+}
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(uri);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function directoryExists(fsPath: string): boolean {
+    try {
+        return fs.statSync(fsPath).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+function resolveExistingIconDirectory(fsPath: string | undefined): string | undefined {
+    if (!fsPath) {
+        return undefined;
+    }
+
+    for (const suffix of ICON_DIRECTORY_CANDIDATE_SUFFIXES) {
+        const candidate = suffix ? path.join(fsPath, suffix) : fsPath;
+        if (directoryExists(candidate) && readPngBaseNames(candidate).size > 0) {
+            return candidate;
+        }
+    }
+
+    return undefined;
+}
+
+function readPngBaseNames(fsPath: string): Set<string> {
+    const names = new Set<string>();
+    try {
+        for (const entry of fs.readdirSync(fsPath, { withFileTypes: true })) {
+            if (entry.isFile() && entry.name.endsWith(".png")) {
+                names.add(entry.name.slice(0, -".png".length));
+            }
+        }
+    } catch {
+        // Ignore unreadable directories and fall back to bundled icons.
+    }
+    return names;
+}
+
+export function getBundledIconsUri(extensionUri: vscode.Uri): vscode.Uri {
+    return vscode.Uri.joinPath(extensionUri, "assets");
+}
+
+export function getCustomIconsUri(): vscode.Uri | undefined {
+    const resolved = resolveExistingIconDirectory(resolveIconDirectoryPath());
+    return resolved ? vscode.Uri.file(resolved) : undefined;
+}
+
+export function getCustomIconClassNames(): Set<string> {
+    const resolved = resolveExistingIconDirectory(resolveIconDirectoryPath());
+    if (!resolved) {
+        return new Set<string>();
+    }
+    return readPngBaseNames(resolved);
+}
+
+export async function resolveIconUri(
+    extensionUri: vscode.Uri,
+    iconName: string,
+): Promise<vscode.Uri> {
+    const customIconsUri = getCustomIconsUri();
+    if (customIconsUri) {
+        const customIconUri = vscode.Uri.joinPath(customIconsUri, `${iconName}.png`);
+        if (await fileExists(customIconUri)) {
+            return customIconUri;
+        }
+    }
+
+    return vscode.Uri.joinPath(getBundledIconsUri(extensionUri), `${iconName}.png`);
+}
+
+export async function getAvailableIconClassNames(
+    extensionUri: vscode.Uri,
+): Promise<Set<string>> {
+    const names = new Set<string>();
+    const sources = [getBundledIconsUri(extensionUri), getCustomIconsUri()].filter(
+        (uri): uri is vscode.Uri => uri !== undefined,
+    );
+
+    for (const source of sources) {
+        try {
+            const entries = await vscode.workspace.fs.readDirectory(source);
+            for (const [name, type] of entries) {
+                if (type === vscode.FileType.File && name.endsWith(".png")) {
+                    names.add(name.slice(0, -".png".length));
+                }
+            }
+        } catch {
+            // Ignore missing or unreadable custom icon directories and fall back to bundled icons.
+        }
+    }
+
+    return names;
+}

--- a/extension/src/robloxClasses.ts
+++ b/extension/src/robloxClasses.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as https from "https";
+import { getAvailableIconClassNames } from "./iconResolver";
 
 const COMMON_CLASS_NAMES = [
     "Part",
@@ -315,15 +316,7 @@ function buildList(creatable: string[], iconClassNames: Set<string>): string[] {
 }
 
 async function getIconClassNames(context: vscode.ExtensionContext): Promise<Set<string>> {
-    const assetsUri = vscode.Uri.joinPath(context.extensionUri, "assets");
-    const entries = await vscode.workspace.fs.readDirectory(assetsUri);
-    const names = new Set<string>();
-    for (const [name, type] of entries) {
-        if (type === vscode.FileType.File && name.endsWith(".png")) {
-            names.add(name.slice(0, -".png".length));
-        }
-    }
-    return names;
+    return getAvailableIconClassNames(context.extensionUri);
 }
 
 function fetchCreatableClasses(): Promise<string[]> {


### PR DESCRIPTION
Support configurable custom icon packs with deterministic fallback

- add `verde.iconDirectory` setting for custom class icon overrides
- resolve either the icon directory itself or a supported pack root containing `RobloxCustom/instance/16x/200`
- prefer the first candidate that actually contains PNGs
- use custom icons per file when present and bundled icons otherwise
- refresh explorer/icon state when the setting changes
- document the supported icon directory layout